### PR TITLE
Expand upon example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A barebones client for [message-db](https://github.com/message-db/message-db) im
 
 Everything, including pub/sub, is exposed through the `MessageDB` interface.
 
-```
+```go
 type MessageDB interface {
         CreateSubscription(streamName, subscriberID string, subscribers Subscribers) Subscription
         Read(streamName string, position, batchSize int) (Messages, error)
@@ -21,20 +21,35 @@ Call `messagedb.New(db)` and provide it a `*sql.DB` and you are ready to go!
 
 For example:
 
-```
-db, err := sql.Open("postgres", "dbname=message_store")
-if err != nil {
-	log.Fatalf("unexpected error opening db: %s", err)
+```go
+package main
+
+import (
+	"database/sql"
+	"log"
+
+	"github.com/brycedarling/messagedb"
+	_ "github.com/lib/pq"
+)
+
+func main() {
+	db, err := sql.Open("postgres", "dbname=message_store sslmode=disable user=postgres")
+	if err != nil {
+		log.Fatalf("unexpected error opening db: %s", err)
+	}
+	defer db.Close()
+
+	db.Exec("SET search_path TO message_store,public;")
+
+	m := messagedb.New(db)
+
+	msgs, err := m.ReadAll("stream")
+	if err != nil {
+		log.Fatalf("unexpected error reading stream: %s", err)
+	}
+
+	log.Printf("Read %d messages from stream", len(msgs))
 }
-defer db.Close()
 
-m := messagedb.New(db)
-
-msgs, err := m.ReadAll("stream")
-if err != nil {
-	log.Fatalf("unexpected error reading stream: %s", err)
-}
-
-log.Printf("Read %d messages from stream", len(msgs))
 ```
 


### PR DESCRIPTION
Hey, I found this package very useful in getting started with message-db, thanks!

This is a small PR to expand upon the README example so that it's runnable against a default install of message-db. I hit [this issue](https://github.com/message-db/message-db/issues/24) on my first attempt, so have included setting the search path in the example. SQL is far from my expertise so feel free to close this if it doesn't make sense.